### PR TITLE
fix(BiGraph): incompatibility readEnhance plugin

### DIFF
--- a/src/.vuepress/plugins/BiGraph/client/components/backlink.vue
+++ b/src/.vuepress/plugins/BiGraph/client/components/backlink.vue
@@ -32,7 +32,8 @@ const tot_link = computed(() => {
 
 <style scoped>
 .backlink-container {
-  margin: 20px 50px;
+  max-width: var(--content-width, 740px);
+  margin-inline: auto;
   padding: 10px;
   border-top: 1px solid #ddd;
 }


### PR DESCRIPTION
预期：

![图片](https://github.com/user-attachments/assets/f7199e04-6a7c-4796-8aef-4d3acc0437f0)

实际：

![图片](https://github.com/user-attachments/assets/8f3a11e0-948d-4ed9-8e2f-e298df1fcdf8)

该commit将后者修正回前者，且与其上下元素（`div.theme-hope-content`、`footer.vp-page-meta`）保持一致性