### PR TITLE
fix(biGraph): link error when default base

### DIFF
--- a/src/.vuepress/plugins/BiGraph/client/components/backlink.vue
+++ b/src/.vuepress/plugins/BiGraph/client/components/backlink.vue
@@ -14,6 +14,7 @@ const tot_link = computed(() => {
 
 /** 转为合适于router所使用的to链接 */
 function to_router_link(link: string) {
+  if (link === "README.html") return "/"
   link = link.replace(/\/README.html$/, '/')
   link = '/' + link
   return link


### PR DESCRIPTION
上次 commit 忽略了一种情况，并非所有的 `README.html` 前面都有 `/`，最根部的那个页面没有